### PR TITLE
Autocomplete functionality (slow but working)

### DIFF
--- a/src/server/server.go
+++ b/src/server/server.go
@@ -16,9 +16,13 @@ type RouteResponse struct {
 func main() {
 	db := structs.Connect()
 	graph := structs.InitGraph(1000).Load(db)
+	terms := structs.NewAutocomplete(db)
 
 	router := gin.Default()
 
+	/**
+	 * Primary route; used for pathfinding between two destinations.
+	 */
 	router.GET("/route", func(ctx *gin.Context) {
 		if ctx.Query("from") == "" || ctx.Query("to") == "" {
 			ctx.JSON(http.StatusBadRequest, RouteResponse{
@@ -47,6 +51,17 @@ func main() {
 				Route:  route,
 			})
 		}
+	})
+
+	/**
+	 * Secondary route: used for autocompleting system names.
+	 */
+
+	router.GET("/search", func(ctx *gin.Context) {
+		query := ctx.Query("q")
+
+		// Find terms
+		ctx.JSON(http.StatusOK, terms.GetAll(query, 5))
 	})
 
 	router.Run()

--- a/src/structs/autocomplete.go
+++ b/src/structs/autocomplete.go
@@ -1,0 +1,56 @@
+package structs
+
+import "strings"
+
+type SystemRecord struct {
+	Name string
+	ID   SystemID
+}
+
+type Autocomplete struct {
+	records []*SystemRecord
+}
+
+func NewAutocomplete(db *SpaceDB) Autocomplete {
+	ac := Autocomplete{
+		records: make([]*SystemRecord, 0),
+	}
+
+	// Populate the autocorrecter
+	db.ForEachSystem(func(system SpaceSystem) {
+		ac.Add(&SystemRecord{
+			Name: system.Name,
+			ID:   system.ID,
+		})
+	})
+
+	return ac
+}
+
+/**
+ * Add a new system record. Will be returned immediately
+ */
+func (ac *Autocomplete) Add(record *SystemRecord) {
+	ac.records = append(ac.records, record)
+}
+
+/**
+ * Returns up to LIMIT records that match the provided string.
+ */
+func (ac *Autocomplete) GetAll(fragment string, limit int) []*SystemRecord {
+	results := make([]*SystemRecord, 0, limit)
+
+	// Very slow implementation currently
+	for _, record := range ac.records {
+		if strings.Contains(strings.ToLower(record.Name), strings.ToLower(fragment)) {
+			results = append(results, record)
+		}
+
+		// Call it quits early if we reach the cap
+		if len(results) == limit {
+			return results
+		}
+	}
+
+	return results
+}


### PR DESCRIPTION
Finds all **system names** that **start with** the specified substring. Currently `O(n)`.
